### PR TITLE
Changed mite domain name to mite.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # miteclock
 
-A command-line for [mite](https://mite.yo.lk/) that gets out of your way!
+A command-line for [mite](https://mite.de/) that gets out of your way!
 
 Do you track time in mite, but wish you could control the clock with a few keystrokes
 from the nearest terminal window? Then give miteclock a try!
@@ -324,7 +324,7 @@ deliberately expose a simple interface and deal only in relevant concepts.
 ## Acknowledgements
 
 This project would not have been possible at all without the folks
-[who run mite](https://mite.yo.lk/) making their API accessible. Many thanks to them for
+[who run mite](https://mite.de/) making their API accessible. Many thanks to them for
 that. I am also grateful to the people who wrote client libraries and cli tools based on
 the API. This provided context to my efforts and thus helped me define what I wanted to
 focus on.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "miteclock"
 version = "22.3"
-description = "Clock in and out of mite.yo.lk quickly."
+description = "Clock in and out of mite.de quickly."
 authors = ["Ilia Kurenkov <ilia.kurenkov@gmail.com>"]
 license="MIT"
 readme = "README.md"

--- a/src/miteclock/settings.py
+++ b/src/miteclock/settings.py
@@ -115,7 +115,7 @@ class MiteURL:
 
     @host.validator
     def mite_base_url(self, attr: attrs.Attribute, val: str):
-        if not val.endswith("mite.yo.lk"):
+        if not (val.endswith("mite.de") or val.endswith("mite.yo.lk")):
             raise ValueError("Make sure you are using a mite url.")
 
     @classmethod
@@ -223,7 +223,7 @@ def _load_valid_config(**kwargs) -> Config:
 
 def _convert_legacy(parsed: Dict) -> Config:
     account = parsed.pop("account")
-    return Config(url=f"https://{account}.mite.yo.lk", **parsed)
+    return Config(url=f"https://{account}.mite.de", **parsed)
 
 
 def _parse_toml(raw: str) -> Dict:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -376,12 +376,12 @@ def test_missing_config_dir(tmp_path):
     If valid input is supplied, we succeed.
     """
     result = CliRunner().invoke(
-        cli.main, obj=tmp_path, input="6d12e0bf974df0e9\nhttps://abc.mite.yo.lk\n"
+        cli.main, obj=tmp_path, input="6d12e0bf974df0e9\nhttps://abc.mite.de\n"
     )
     assert result.exit_code == 0
     assert result.output == (
         "Key not found, please enter it: 6d12e0bf974df0e9\n"
-        + "Please copy/paste your mite URL: https://abc.mite.yo.lk\n"
+        + "Please copy/paste your mite URL: https://abc.mite.de\n"
         + HELP_MSG
     )
     assert (

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -87,7 +87,7 @@ def test_load_api_key_invalid(key, errmsg, tmp_path):
 
 def test_default_toml_content():
     """Toml content for the default config."""
-    url = "https://abc.mite.yo.lk"
+    url = "https://abc.mite.de"
     assert to_toml(Config(url=url)) == (
         f'url = "{url}"\n'
         'menu_keys = "asdfjkl;"\n\n'
@@ -102,10 +102,10 @@ def test_load_config_does_not_exist(conf_path, capsys):
     """
     config = load_config(
         conf_path,
-        prompt=prompt_for_testing("https://abc.mite.yo.lk"),
+        prompt=prompt_for_testing("https://abc.mite.de"),
     )
     assert config == Config(
-        url="https://abc.mite.yo.lk", menu_keys="asdfjkl;", shortcuts={}
+        url="https://abc.mite.de", menu_keys="asdfjkl;", shortcuts={}
     )
     out, _ = capsys.readouterr()
     assert out == "Please copy/paste your mite URL"
@@ -119,7 +119,7 @@ def test_load_config_does_not_exist_invalid_url_input(conf_path, capsys):
     with pytest.raises(SettingsLoadError) as excinfo:
         load_config(
             conf_path,
-            prompt=prompt_for_testing("http://abc.mite.yo.lk"),
+            prompt=prompt_for_testing("http://abc.mite.de"),
         )
     assert str(excinfo.value) == (
         "Detected the following problems with your configuration:\n"
@@ -157,7 +157,7 @@ def test_load_config_toml_parse_error(conf_path):
 
 
 def test_load_valid_config(conf_path):
-    base_url = "https://abc.mite.yo.lk"
+    base_url = "https://abc.mite.de"
     conf_path.write_text(
         f'url="{base_url}"\n'
         'menu_keys="abc"\n\n'
@@ -179,7 +179,7 @@ def test_load_valid_config(conf_path):
 
 
 def test_load_valid_legacy_config(conf_path):
-    base_url = "https://abc.mite.yo.lk"
+    base_url = "https://abc.mite.de"
     conf_path.write_text(
         'account="abc"\n'
         'menu_keys="abc"\n\n'
@@ -214,7 +214,7 @@ def test_legacy_config(conf_path):
     )
     config = load_config(conf_path)
     assert config == Config(
-        url="https://abc.mite.yo.lk",
+        url="https://abc.mite.de",
         menu_keys="abc",
     )
 
@@ -224,7 +224,7 @@ def test_legacy_config(conf_path):
 )
 def test_url_remove_path(url_path):
     """If we get any kind of path added to a URL we keep only the base."""
-    base_url = "https://abc.mite.yo.lk"
+    base_url = "https://abc.mite.de"
     assert str(Config(url=base_url + url_path).url) == base_url
 
 
@@ -238,5 +238,5 @@ def test_non_mite_url():
 def test_no_menu_keys():
     """At least one menu key should be specified, otherwise we crash early."""
     with pytest.raises(ValueError) as excinfo:
-        Config(url="https://abc.mite.yo.lk", menu_keys="")
+        Config(url="https://abc.mite.de", menu_keys="")
     assert str(excinfo.value) == "menu_keys: At least one key must be provided."


### PR DESCRIPTION
The domain schema of the mite API changed from {account}.mite.yo.lk to {account}.mite.de. The old schema continues to work, so I allowed both when checking the user settings.